### PR TITLE
Create Self-Signed Certificates on the ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The library is self-contained and just needs the Arduino and ESP32 system librar
 
 Clone or download the content of this git repository into your Arduino/libraries folder and restart you IDE.
 
-To run the examples, you need to execute the script extras/create_cert.sh first. This script will create a simple CA to sign certificates that are used with the examples. Some notes on the usage can be found in the extras/README.md file.
+To run the examples (except for the _Self-Signed-Certificates_ example), you need to execute the script extras/create_cert.sh first. This script will create a simple CA to sign certificates that are used with the examples. Some notes on the usage can be found in the extras/README.md file.
 
 You then should be able to add the library to your project if you selected the ESP32 as architecture.
 
@@ -37,6 +37,7 @@ You will find several examples showing how you can use the library:
 - [Async-Server](examples/Async-Server/Async-Server.ino): Like the Static-Page example, but the server runs in a separate task on the ESP32, so you do not need to call the loop() function in your main sketch.
 - [Websocket-Chat](examples/Websocket-Chat/Websocket-Chat.ino): Provides a browser-based chat built on top of websockets. **Note:** Websockets are still under development!
 - [Parameter-Validation](examples/Parameter-Validation/Parameter-Validation.ino): Shows how you can integrate validator functions to do formal checks on parameters in your URL.
+- [Self-Signed-Certificate](examples/Self-Signed/Self-Signed.ino): Shows how to generate a self-signed certificate on the fly on the ESP when the sketch starts. You do not need to run `create_cert.sh` to use this example.
 
 If you encounter error messages that cert.h or private\_key.h are missing when running an example, make sure to run create\_cert.sh first (see Setup Instructions).
 
@@ -145,3 +146,34 @@ By default, you need to pass control to the server explicitly. This is done by c
 If you want to have the server running in the background (and not calling `loop()` by yourself every few milliseconds), you can make use of the ESP32's task feature and put the whole server in a separate task.
 
 See the Async-Server example to see how this can be done.
+
+## Advanced Configuration
+
+This section covers some advanced configuration options that allow you e.g. to customize the build process, but which might require more advanced programming skills and a more sophisticated IDE that just the default Arduino IDE.
+
+### Saving Space by Reducing Functionality
+
+To save program space on the microcontroller, there are some parts of the library that can be disabled during compilation and will then not be a part of your program.
+
+The following flags are currently available:
+
+| Flag                      | Effect
+| ------------------------- | ---------------------------
+| HTTPS_DISABLE_SELFSIGNING | Removes the code for generating a self-signed certificate at runtime. You will need to provide certificate and private key data from another data source to use the `HTTPSServer`.
+
+Setting these flags requires a build environment that gives you some control of the compiler, as libraries are usually compiled separately, so just doing a `#define HTTPS_SOMETHING` in your sketch will not work.
+
+**Example: Configuration with Platform IO**
+
+To set these flags in Platform IO, you can modify your `platformio.ini`. To disable for example the self-signed-certificates part of the library, the file could look like this:
+
+```ini
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+build_flags =
+  -DHTTPS_DISABLE_SELFSIGNING
+```
+
+Note the `-D` in front of the actual flag name, that passes this flag as a definition to the preprocessor. Multiple flags can be added one per line.

--- a/examples/Self-Signed-Certificate/Self-Signed-Certificate.ino
+++ b/examples/Self-Signed-Certificate/Self-Signed-Certificate.ino
@@ -56,7 +56,15 @@ void setup() {
   // - Distinguished name: The name of the host as used in certificates.
   //   If you want to run your own DNS, the part after CN (Common Name) should match the DNS
   //   entry pointing to your ESP32. You can try to insert an IP there, but that's not really good style.
-  int createCertResult = createSelfSignedCert(*cert, KEYSIZE_2048, "CN=myesp32.local,O=FancyCompany,C=DE");
+  // - Dates for certificate validity (optional, default is 2019-2029, both included)
+  //   Format is YYYYMMDDhhmmss
+  int createCertResult = createSelfSignedCert(
+    *cert,
+    KEYSIZE_2048,
+    "CN=myesp32.local,O=FancyCompany,C=DE",
+    "20190101000000",
+    "20300101000000"
+  );
 
   // Now check if creating that worked
   if (createCertResult != 0) {

--- a/examples/Self-Signed-Certificate/Self-Signed-Certificate.ino
+++ b/examples/Self-Signed-Certificate/Self-Signed-Certificate.ino
@@ -1,0 +1,164 @@
+/**
+ * Example for the ESP32 HTTP(S) Webserver
+ *
+ * IMPORTANT NOTE:
+ * To run this script, you need to
+ *  1) Enter your WiFi SSID and PSK below this comment
+ *
+ * This script will install an HTTPS Server on your ESP32 with the following
+ * functionalities:
+ *  - Show simple page on web server root
+ *  - 404 for everything else
+ * 
+ * In contrast to the other examples, the certificate and the private key will be
+ * generated on the ESP32, so you do not need to provide them here.
+ * (this means no need to run create_cert.sh)
+ */
+
+// TODO: Configure your WiFi here
+#define WIFI_SSID "<your ssid goes here>"
+#define WIFI_PSK  "<your pre-shared key goes here>"
+
+// We will use wifi
+#include <WiFi.h>
+
+// Includes for the server
+#include <HTTPSServer.hpp>
+#include <SSLCert.hpp>
+#include <HTTPRequest.hpp>
+#include <HTTPResponse.hpp>
+
+// The HTTPS Server comes in a separate namespace. For easier use, include it here.
+using namespace httpsserver;
+
+SSLCert * cert;
+HTTPSServer * secureServer;
+
+// Declare some handler functions for the various URLs on the server
+void handleRoot(HTTPRequest * req, HTTPResponse * res);
+void handle404(HTTPRequest * req, HTTPResponse * res);
+
+void setup() {
+  // For logging
+  Serial.begin(115200);
+  delay(3000); // wait for the monitor to reconnect after uploading.
+
+  Serial.println("Creating a new self-signed certificate.");
+  Serial.println("This may take up to a minute, so be patient ;-)");
+
+  // First, we create an empty certificate:
+  cert = new SSLCert();
+
+  // Now, we use the function createSelfSignedCert to create private key and certificate.
+  // The function takes the following paramters:
+  // - Key size: 1024 or 2048 bit should be fine here, 4096 on the ESP might be "paranoid mode"
+  //   (in generel: shorter key = faster but less secure)
+  // - Distinguished name: The name of the host as used in certificates.
+  //   If you want to run your own DNS, the part after CN (Common Name) should match the DNS
+  //   entry pointing to your ESP32. You can try to insert an IP there, but that's not really good style.
+  int createCertResult = createSelfSignedCert(*cert, KEYSIZE_2048, "CN=myesp32.local,O=FancyCompany,C=DE");
+
+  // Now check if creating that worked
+  if (createCertResult != 0) {
+    Serial.printf("Cerating certificate failed. Error Code = 0x%02X, check SSLCert.hpp for details", createCertResult);
+    while(true) delay(500);
+  }
+  Serial.println("Creating the certificate was successful");
+
+  // If you're working on a serious project, this would be a good place to initialize some form of non-volatile storage
+  // and to put the certificate and the key there. This has the advantage that the certificate stays the same after a reboot
+  // so your client still trusts your server, additionally you increase the speed-up of your application.
+  // Some browsers like Firefox might even reject the second run for the same issuer name (the distinguished name defined above).
+  //
+  // Storing:
+  //   For the key:
+  //     cert->getPKLength() will return the length of the private key in byte
+  //     cert->getPKData() will return the actual private key (in DER-format, if that matters to you)
+  //   For the certificate:
+  //     cert->getCertLength() and ->getCertData() do the same for the actual certificate data.
+  // Restoring:
+  //   When your applications boots, check your non-volatile storage for an existing certificate, and if you find one
+  //   use the parameterized SSLCert constructor to re-create the certificate and pass it to the HTTPSServer.
+  //
+  // A short reminder on key security: If you're working on something professional, be aware that the storage of the ESP32 is
+  // not encrypted in any way. This means that if you just write it to the flash storage, it is easy to extract it if someone
+  // gets a hand on your hardware. You should decide if that's a relevant risk for you and apply countermeasures like flash
+  // encryption if neccessary
+
+  // We can now use the new certificate to setup our server as usual.
+	secureServer = new HTTPSServer(cert);
+
+  // Connect to WiFi
+  Serial.println("Setting up WiFi");
+  WiFi.begin(WIFI_SSID, WIFI_PSK);
+  while (WiFi.status() != WL_CONNECTED) {
+    Serial.print(".");
+    delay(500);
+  }
+  Serial.print("Connected. IP=");
+  Serial.println(WiFi.localIP());
+
+  // For every resource available on the server, we need to create a ResourceNode
+  // The ResourceNode links URL and HTTP method to a handler function
+  ResourceNode * nodeRoot    = new ResourceNode("/", "GET", &handleRoot);
+  ResourceNode * node404     = new ResourceNode("", "GET", &handle404);
+
+  // Add the root node to the server
+  secureServer->registerNode(nodeRoot);
+  // Add the 404 not found node to the server.
+  secureServer->setDefaultNode(node404);
+
+  Serial.println("Starting server...");
+  secureServer->start();
+  if (secureServer->isRunning()) {
+	  Serial.println("Server ready.");
+  }
+}
+
+void loop() {
+	// This call will let the server do its work
+	secureServer->loop();
+
+	// Other code would go here...
+	delay(1);
+}
+
+void handleRoot(HTTPRequest * req, HTTPResponse * res) {
+	// Status code is 200 OK by default.
+	// We want to deliver a simple HTML page, so we send a corresponding content type:
+	res->setHeader("Content-Type", "text/html");
+
+	// The response implements the Print interface, so you can use it just like
+	// you would write to Serial etc.
+	res->println("<!DOCTYPE html>");
+	res->println("<html>");
+	res->println("<head><title>Hello World!</title></head>");
+	res->println("<body>");
+	res->println("<h1>Hello World!</h1>");
+	res->print("<p>Your server is running for ");
+	// A bit of dynamic data: Show the uptime
+	res->print((int)(millis()/1000), DEC);
+	res->println(" seconds.</p>");
+	res->println("</body>");
+	res->println("</html>");
+}
+
+void handle404(HTTPRequest * req, HTTPResponse * res) {
+	// Discard request body, if we received any
+	// We do this, as this is the default node and may also server POST/PUT requests
+	req->discardRequestBody();
+
+	// Set the response status
+	res->setStatusCode(404);
+	res->setStatusText("Not Found");
+
+	// Set content type of the response
+	res->setHeader("Content-Type", "text/html");
+
+	// Write a tiny HTTP page
+	res->println("<!DOCTYPE html>");
+	res->println("<html>");
+	res->println("<head><title>Not Found</title></head>");
+	res->println("<body><h1>404 Not Found</h1><p>The requested resource was not found on this server.</p></body>");
+	res->println("</html>");
+}

--- a/src/SSLCert.cpp
+++ b/src/SSLCert.cpp
@@ -31,4 +31,280 @@ unsigned char * SSLCert::getPKData() {
 	return _pkData;
 }
 
+void SSLCert::setPK(unsigned char * pkData, uint16_t length) {
+	_pkData = pkData;
+	_pkLength = length;
+}
+
+void SSLCert::setCert(unsigned char * certData, uint16_t length) {
+	_certData = certData;
+	_certLength = length;
+}
+
+void SSLCert::clear() {
+	for(uint16_t i = 0; i < _certLength; i++) _certData[i]=0;
+	delete _certData;
+	_certLength = 0;
+
+	for(uint16_t i = 0; i < _pkLength; i++) _pkData[i] = 0;
+	delete _pkData;
+	_pkLength = 0;
+}
+
+#ifndef HTTPS_DISABLE_SELFSIGNING
+
+/**
+ * Function to create the key for a self-signed certificate.
+ * 
+ * Writes private key as DER in certCtx
+ * 
+ * Based on programs/pkey/gen_key.c
+ */
+static int gen_key(SSLCert &certCtx, SSLKeySize keySize) {
+
+	// Initialize the entropy source
+	mbedtls_entropy_context entropy;
+	mbedtls_entropy_init( &entropy );
+
+	// Initialize the RNG
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_ctr_drbg_init( &ctr_drbg );
+	int rngRes = mbedtls_ctr_drbg_seed(
+		&ctr_drbg, mbedtls_entropy_func, &entropy,
+		NULL, 0
+	);
+  if (rngRes != 0) {
+		mbedtls_entropy_free( &entropy );
+		return HTTPS_SERVER_ERROR_KEYGEN_RNG;
+	}
+
+	// Initialize the private key
+	mbedtls_pk_context key;
+	mbedtls_pk_init( &key );
+	int resPkSetup = mbedtls_pk_setup( &key, mbedtls_pk_info_from_type( MBEDTLS_PK_RSA ) );
+	if ( resPkSetup != 0) {
+		mbedtls_ctr_drbg_free( &ctr_drbg );
+		mbedtls_entropy_free( &entropy );
+		return HTTPS_SERVER_ERROR_KEYGEN_SETUP_PK;
+	}
+
+	// Actual key generation 
+  int resPkGen = mbedtls_rsa_gen_key(
+		mbedtls_pk_rsa( key ),
+		mbedtls_ctr_drbg_random,
+		&ctr_drbg,
+		keySize,
+		65537
+	);
+	if ( resPkGen != 0) {
+		mbedtls_pk_free( &key );
+		mbedtls_ctr_drbg_free( &ctr_drbg );
+		mbedtls_entropy_free( &entropy );
+		return HTTPS_SERVER_ERROR_KEYGEN_GEN_PK;
+	}
+
+	// Free the entropy source and the RNG as they are no longer needed
+	mbedtls_ctr_drbg_free( &ctr_drbg );
+	mbedtls_entropy_free( &entropy );
+
+	// Allocate the space on the heap, as stack size is quite limited
+	unsigned char * output_buf = new unsigned char[4096];
+	if (output_buf == NULL) {
+		mbedtls_pk_free( &key );
+		return HTTPS_SERVER_ERROR_KEY_OUT_OF_MEM;
+	}
+	memset(output_buf, 0, 4096);
+
+	// Write the key to the temporary buffer and determine its length
+	int resPkWrite = mbedtls_pk_write_key_der( &key, output_buf, 4096 );
+	if (resPkWrite < 0) {
+		delete[] output_buf;
+		mbedtls_pk_free( &key );
+		return HTTPS_SERVER_ERROR_KEY_WRITE_PK;
+	}
+	size_t pkLength = resPkWrite;
+	unsigned char *pkOffset = output_buf + sizeof(unsigned char) * 4096 - pkLength;
+
+	// Copy the key into a new, fitting space on the heap
+	unsigned char * output_pk = new unsigned char[pkLength];
+	if (output_pk == NULL) {
+		delete[] output_buf;
+		mbedtls_pk_free( &key );
+		return HTTPS_SERVER_ERROR_KEY_WRITE_PK;
+	}
+	memcpy(output_pk, pkOffset, pkLength);
+
+	// Clean up the temporary buffer and clear the key context
+	delete[] output_buf;
+	mbedtls_pk_free( &key );
+
+	// Set the private key in the context
+	certCtx.setPK(output_pk, pkLength);
+
+	return 0;
+}
+
+/**
+ * Function to generate the X509 certificate data for a private key
+ * 
+ * Writes certificate in certCtx
+ *
+ * Based on programs/x509/cert_write.c
+ */
+static int cert_write(SSLCert &certCtx, std::string dn) {
+	int funcRes = 0;
+	int stepRes = 0;
+
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_pk_context key;
+	mbedtls_x509write_cert crt;
+	mbedtls_mpi serial;
+	unsigned char * primary_buffer;
+	unsigned char *certOffset;
+	unsigned char * output_buffer;
+	size_t certLength;
+
+	// Make a C-friendly version of the distinguished name
+	char dn_cstr[dn.length()+1];
+	strcpy(dn_cstr, dn.c_str());
+
+	// Initialize the entropy source
+	mbedtls_entropy_init( &entropy );
+
+	// Initialize the RNG
+	mbedtls_ctr_drbg_init( &ctr_drbg );
+	stepRes = mbedtls_ctr_drbg_seed( &ctr_drbg, mbedtls_entropy_func, &entropy, NULL, 0 );
+  if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_RNG;
+		goto error_after_entropy;
+	}
+
+	mbedtls_pk_init( &key );
+	stepRes = mbedtls_pk_parse_key( &key, certCtx.getPKData(), certCtx.getPKLength(), NULL, 0 );
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_READKEY;
+		goto error_after_key;
+	}
+
+	// Start configuring the certificate
+	mbedtls_x509write_crt_init( &crt );
+	// Set version and hash algorithm
+	mbedtls_x509write_crt_set_version( &crt, MBEDTLS_X509_CRT_VERSION_3 );
+	mbedtls_x509write_crt_set_md_alg( &crt, MBEDTLS_MD_SHA256 );
+
+	// Set the keys (same key as we self-sign)
+	mbedtls_x509write_crt_set_subject_key( &crt, &key );
+	mbedtls_x509write_crt_set_issuer_key( &crt, &key );
+
+	// Set issuer and subject (same, as we self-sign)
+	stepRes = mbedtls_x509write_crt_set_subject_name( &crt, dn_cstr );
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_NAME;
+		goto error_after_cert;
+	}
+	stepRes = mbedtls_x509write_crt_set_issuer_name( &crt, dn_cstr );
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_NAME;
+		goto error_after_cert;
+	}
+
+  // Set the validity of the certificate. At the moment, it's fixed from 2019 to end of 2029.
+	stepRes = mbedtls_x509write_crt_set_validity( &crt, "20190101000000", "20300101000000");
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_VALIDITY;
+		goto error_after_cert;
+	}
+
+	// Make this a CA certificate
+	stepRes = mbedtls_x509write_crt_set_basic_constraints( &crt, 1, 0 );
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_VALIDITY;
+		goto error_after_cert;
+	}
+
+	// Initialize the serial number
+	mbedtls_mpi_init( &serial );
+	stepRes = mbedtls_mpi_read_string( &serial, 10, "1" );
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_SERIAL;
+		goto error_after_cert_serial;
+	}
+	stepRes = mbedtls_x509write_crt_set_serial( &crt, &serial );
+	if (stepRes != 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_SERIAL;
+		goto error_after_cert_serial;
+	}
+
+	// Create buffer to write the certificate
+	primary_buffer = new unsigned char[4096];
+	if (primary_buffer == NULL) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_OUT_OF_MEM;
+		goto error_after_cert_serial;
+	}
+
+	// Write the actual certificate
+	stepRes = mbedtls_x509write_crt_der(&crt, primary_buffer, 4096, mbedtls_ctr_drbg_random, &ctr_drbg );
+	if (stepRes < 0) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_WRITE;
+		goto error_after_primary_buffer;
+	}
+
+	// Create a matching buffer
+  certLength = stepRes;
+	certOffset = primary_buffer + sizeof(unsigned char) * 4096 - certLength;
+
+	// Copy the cert into a new, fitting space on the heap
+	output_buffer = new unsigned char[certLength];
+	if (output_buffer == NULL) {
+		funcRes = HTTPS_SERVER_ERROR_CERTGEN_OUT_OF_MEM;
+		goto error_after_primary_buffer;
+	}
+	memcpy(output_buffer, certOffset, certLength);
+
+	// Configure the cert in the context
+	certCtx.setCert(output_buffer, certLength);
+
+	// Run through the cleanup process
+error_after_primary_buffer:
+	delete[] primary_buffer;
+
+error_after_cert_serial:
+	mbedtls_mpi_free( &serial );
+
+error_after_cert:
+	mbedtls_x509write_crt_free( &crt );
+
+error_after_key:
+	mbedtls_pk_free(&key);
+
+error_after_entropy:
+	mbedtls_ctr_drbg_free( &ctr_drbg );
+	mbedtls_entropy_free( &entropy );
+	return funcRes;
+}
+
+int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn) {
+	
+	// Add the private key
+	int keyRes = gen_key(certCtx, keySize);
+	if (keyRes != 0) {
+		// Key-generation failed, return the failure code
+		return keyRes;
+	}
+
+	// Add the self-signed certificate
+	int certRes = cert_write(certCtx, dn);
+	if (certRes != 0) {
+		// Cert writing failed, reset the pk and return failure code
+		certCtx.setPK(NULL, 0);
+		return certRes;
+	}
+
+	// If all went well, return 0
+	return 0;
+}
+
+#endif // !HTTPS_DISABLE_SELFSIGNING
+
 } /* namespace httpsserver */

--- a/src/SSLCert.cpp
+++ b/src/SSLCert.cpp
@@ -151,7 +151,7 @@ static int gen_key(SSLCert &certCtx, SSLKeySize keySize) {
  *
  * Based on programs/x509/cert_write.c
  */
-static int cert_write(SSLCert &certCtx, std::string dn) {
+static int cert_write(SSLCert &certCtx, std::string dn, std::string validityFrom, std::string validityTo) {
 	int funcRes = 0;
 	int stepRes = 0;
 
@@ -210,7 +210,7 @@ static int cert_write(SSLCert &certCtx, std::string dn) {
 	}
 
   // Set the validity of the certificate. At the moment, it's fixed from 2019 to end of 2029.
-	stepRes = mbedtls_x509write_crt_set_validity( &crt, "20190101000000", "20300101000000");
+	stepRes = mbedtls_x509write_crt_set_validity( &crt, validityFrom.c_str(), validityTo.c_str());
 	if (stepRes != 0) {
 		funcRes = HTTPS_SERVER_ERROR_CERTGEN_VALIDITY;
 		goto error_after_cert;
@@ -284,8 +284,8 @@ error_after_entropy:
 	return funcRes;
 }
 
-int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn) {
-	
+int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn, std::string validFrom, std::string validUntil) {
+
 	// Add the private key
 	int keyRes = gen_key(certCtx, keySize);
 	if (keyRes != 0) {
@@ -294,7 +294,7 @@ int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn) {
 	}
 
 	// Add the self-signed certificate
-	int certRes = cert_write(certCtx, dn);
+	int certRes = cert_write(certCtx, dn, validFrom, validUntil);
 	if (certRes != 0) {
 		// Cert writing failed, reset the pk and return failure code
 		certCtx.setPK(NULL, 0);

--- a/src/SSLCert.hpp
+++ b/src/SSLCert.hpp
@@ -77,10 +77,13 @@ enum SSLKeySize {
  * would be:
  *   CN=myesp.local,O=acme,C=US
  * 
+ * The strings validFrom and validUntil have to be formatted like this:
+ * "20190101000000", "20300101000000"
+ * 
  * This will take some time, so you should probably write the certificate data to non-volatile
  * storage when you are done.
  */
-int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn);
+int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn, std::string validFrom = "20190101000000", std::string validUntil = "20300101000000");
 
 #endif // !HTTPS_DISABLE_SELFSIGNING
 

--- a/src/SSLCert.hpp
+++ b/src/SSLCert.hpp
@@ -3,17 +3,55 @@
 
 #include <Arduino.h>
 
+#ifndef HTTPS_DISABLE_SELFSIGNING
+#include <string>
+#include <mbedtls/rsa.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/x509.h>
+#include <mbedtls/x509_crt.h>
+#include <mbedtls/x509_csr.h>
+
+#define HTTPS_SERVER_ERROR_KEYGEN 0x0F
+#define HTTPS_SERVER_ERROR_KEYGEN_RNG 0x02
+#define HTTPS_SERVER_ERROR_KEYGEN_SETUP_PK 0x03
+#define HTTPS_SERVER_ERROR_KEYGEN_GEN_PK 0x04
+#define HTTPS_SERVER_ERROR_KEY_WRITE_PK 0x05
+#define HTTPS_SERVER_ERROR_KEY_OUT_OF_MEM 0x06
+#define HTTPS_SERVER_ERROR_CERTGEN 0x1F
+#define HTTPS_SERVER_ERROR_CERTGEN_RNG 0x12
+#define HTTPS_SERVER_ERROR_CERTGEN_READKEY 0x13
+#define HTTPS_SERVER_ERROR_CERTGEN_WRITE 0x15
+#define HTTPS_SERVER_ERROR_CERTGEN_OUT_OF_MEM 0x16
+#define HTTPS_SERVER_ERROR_CERTGEN_NAME 0x17
+#define HTTPS_SERVER_ERROR_CERTGEN_SERIAL 0x18
+#define HTTPS_SERVER_ERROR_CERTGEN_VALIDITY 0x19
+
+#endif // !HTTPS_DISABLE_SELFSIGNING
+
 namespace httpsserver {
 
 class SSLCert {
 public:
-	SSLCert(unsigned char * certData, uint16_t certLength, unsigned char * pkData, uint16_t pkLength);
+	SSLCert(
+		unsigned char * certData = NULL,
+		uint16_t certLength = 0,
+		unsigned char * pkData = NULL,
+		uint16_t pkLength = 0
+	);
 	virtual ~SSLCert();
 
 	uint16_t getCertLength();
 	uint16_t getPKLength();
 	unsigned char * getCertData();
 	unsigned char * getPKData();
+
+	void setPK(unsigned char * _pkData, uint16_t length);
+	void setCert(unsigned char * _certData, uint16_t length);
+
+	/** Clears the key buffers and delets them. */
+	void clear();
 
 private:
 	uint16_t _certLength;
@@ -22,6 +60,29 @@ private:
 	unsigned char * _pkData;
 
 };
+
+#ifndef HTTPS_DISABLE_SELFSIGNING
+
+enum SSLKeySize {
+	KEYSIZE_1024 = 1024,
+	KEYSIZE_2048 = 2048,
+	KEYSIZE_4096 = 4096
+};
+
+/**
+ * This function creates a new self-signed certificate for the given hostname on the heap.
+ * Make sure to clear() it before you delete it.
+ * 
+ * The distinguished name (dn) parameter has to follow the x509 specifications. An example
+ * would be:
+ *   CN=myesp.local,O=acme,C=US
+ * 
+ * This will take some time, so you should probably write the certificate data to non-volatile
+ * storage when you are done.
+ */
+int createSelfSignedCert(SSLCert &certCtx, SSLKeySize keySize, std::string dn);
+
+#endif // !HTTPS_DISABLE_SELFSIGNING
 
 } /* namespace httpsserver */
 


### PR DESCRIPTION
The new code uses mbedtls to create a private key and self-signed certificate directly on the ESP32 to make the setup and evaluation process of the library a bit easier and allow for bigger deployments without the requirement to issue a custom certificate to each device.