### PR TITLE
HTTPConnection::loop respects 'keep-alive' value despite the case sensitivity

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -434,7 +434,12 @@ void HTTPConnection::loop() {
 					if (resolvedResource.getMatchingNode()->_nodeType == HANDLER_CALLBACK) {
 						// Did the client set connection:keep-alive?
 						HTTPHeader * connectionHeader = _httpHeaders->get("Connection");
-						if (connectionHeader != NULL && std::string("keep-alive").compare(connectionHeader->_value)==0) {
+						std::string connectionHeaderValue = "";
+						if (connectionHeader != NULL) {
+							connectionHeaderValue += connectionHeader->_value;
+							std::transform(connectionHeaderValue.begin(), connectionHeaderValue.end(), connectionHeaderValue.begin(), ::tolower);
+						}
+						if (std::string("keep-alive").compare(connectionHeaderValue)==0) {
 							HTTPS_DLOGHEX("[   ] Keep-Alive activated. fid=", _socket);
 							_isKeepAlive = true;
 						} else {


### PR DESCRIPTION
Library I use (Apache HTTP Client) in the client is sending Keep-Alive instead of keep-alive.