### PR TITLE
TLS tickets and FreeRTOS workers

### DIFF
--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -43,7 +43,7 @@ public:
   virtual void closeConnection();
   virtual bool isSecure();
 
-  void loop();
+  bool loop();
   bool isClosed();
   bool isError();
 

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -28,7 +28,7 @@ HTTPRequest::HTTPRequest(
 }
 
 HTTPRequest::~HTTPRequest() {
-  _headers->clearAll();
+  if (_headers) _headers->clearAll();
 }
 
 

--- a/src/HTTPResponse.hpp
+++ b/src/HTTPResponse.hpp
@@ -42,7 +42,9 @@ public:
 
   void error();
 
+  void setContentLength(size_t size);
   bool isResponseBuffered();
+  bool correctContentLength();
   void finalize();
 
   ConnectionContext * _con;
@@ -58,6 +60,10 @@ private:
   HTTPHeaders _headers;
   bool _headerWritten;
   bool _isError;
+
+  // Response length
+  size_t _setLength;
+  size_t _sentBytesCount;
 
   // Response cache
   byte * _responseCache;

--- a/src/HTTPSConnection.cpp
+++ b/src/HTTPSConnection.cpp
@@ -105,19 +105,21 @@ void HTTPSConnection::closeConnection() {
 }
 
 size_t HTTPSConnection::writeBuffer(byte* buffer, size_t length) {
-  return SSL_write(_ssl, buffer, length);
+  if (_ssl != NULL) return SSL_write(_ssl, buffer, length);
+  return 0;
 }
 
 size_t HTTPSConnection::readBytesToBuffer(byte* buffer, size_t length) {
-  return SSL_read(_ssl, buffer, length);
+  if (_ssl != NULL) return SSL_read(_ssl, buffer, length);
+  return 0;
 }
 
 size_t HTTPSConnection::pendingByteCount() {
-  return SSL_pending(_ssl);
+  return (_ssl != NULL) && SSL_pending(_ssl);
 }
 
 bool HTTPSConnection::canReadData() {
-  return HTTPConnection::canReadData() || (SSL_pending(_ssl) > 0);
+  return HTTPConnection::canReadData() || ((_ssl != NULL) && (SSL_pending(_ssl) > 0));
 }
 
 } /* namespace httpsserver */

--- a/src/HTTPSConnection.cpp
+++ b/src/HTTPSConnection.cpp
@@ -6,6 +6,7 @@ namespace httpsserver {
 HTTPSConnection::HTTPSConnection(ResourceResolver * resResolver):
   HTTPConnection(resResolver) {
   _ssl = NULL;
+  _TLSTickets = NULL;
 }
 
 HTTPSConnection::~HTTPSConnection() {
@@ -31,6 +32,7 @@ int HTTPSConnection::initialize(int serverSocketID, SSL_CTX * sslCtx, HTTPHeader
     if (resSocket >= 0) {
 
       _ssl = SSL_new(sslCtx);
+      if (_TLSTickets != NULL) _TLSTickets->enable(_ssl);
 
       if (_ssl) {
         // Bind SSL to the socket

--- a/src/HTTPSConnection.hpp
+++ b/src/HTTPSConnection.hpp
@@ -35,7 +35,8 @@ public:
   HTTPSConnection(ResourceResolver * resResolver);
   virtual ~HTTPSConnection();
 
-  virtual int initialize(int serverSocketID, SSL_CTX * sslCtx, HTTPHeaders *defaultHeaders);
+  virtual void initialize(int serverSocketID, HTTPHeaders *defaultHeaders, SSL_CTX * sslCtx, TLSTickets * tickets);
+  virtual int fullyAccept() override; 
   virtual void closeConnection();
   virtual bool isSecure();
 
@@ -50,6 +51,7 @@ protected:
 
 private:
   // SSL context for this connection
+  SSL_CTX * _sslCtx;
   SSL * _ssl;
 	TLSTickets * _TLSTickets;
 

--- a/src/HTTPSConnection.hpp
+++ b/src/HTTPSConnection.hpp
@@ -23,6 +23,7 @@
 #include "ResourceNode.hpp"
 #include "HTTPRequest.hpp"
 #include "HTTPResponse.hpp"
+#include "TLSTickets.hpp"
 
 namespace httpsserver {
 
@@ -50,6 +51,7 @@ protected:
 private:
   // SSL context for this connection
   SSL * _ssl;
+	TLSTickets * _TLSTickets;
 
 };
 

--- a/src/HTTPSServer.cpp
+++ b/src/HTTPSServer.cpp
@@ -59,10 +59,10 @@ void HTTPSServer::teardownSocket() {
   _sslctx = NULL;
 }
 
-int HTTPSServer::createConnection(int idx) {
+HTTPSConnection * HTTPSServer::createConnection() {
   HTTPSConnection * newConnection = new HTTPSConnection(this);
-  _connections[idx] = newConnection;
-  return newConnection->initialize(_socket, _sslctx, &_defaultHeaders);
+  newConnection->initialize(_socket, &_defaultHeaders, _sslctx, _TLSTickets);
+  return newConnection;
 }
 
 /**

--- a/src/HTTPSServer.cpp
+++ b/src/HTTPSServer.cpp
@@ -9,6 +9,7 @@ HTTPSServer::HTTPSServer(SSLCert * cert, const uint16_t port, const uint8_t maxC
 
   // Configure runtime data
   _sslctx = NULL;
+  _TLSTickets = NULL;
 }
 
 HTTPSServer::~HTTPSServer() {
@@ -43,6 +44,10 @@ uint8_t HTTPSServer::setupSocket() {
   } else {
     return 1;
   }
+}
+
+void HTTPSServer::enableTLSTickets(uint32_t liftimeSeconds, bool useHardwareRNG) {
+  _TLSTickets = new TLSTickets("esp32_https_server", liftimeSeconds, useHardwareRNG);
 }
 
 void HTTPSServer::teardownSocket() {

--- a/src/HTTPSServer.hpp
+++ b/src/HTTPSServer.hpp
@@ -21,6 +21,7 @@
 #include "ResolvedResource.hpp"
 #include "HTTPSConnection.hpp"
 #include "SSLCert.hpp"
+#include "TLSTickets.hpp"
 
 namespace httpsserver {
 
@@ -32,6 +33,9 @@ public:
   HTTPSServer(SSLCert * cert, const uint16_t portHTTPS = 443, const uint8_t maxConnections = 4, const in_addr_t bindAddress = 0);
   virtual ~HTTPSServer();
 
+  // RFC 5077 TLS session tickets
+  void enableTLSTickets(uint32_t liftimeSeconds = 86400, bool useHardwareRNG = false);
+
 private:
   // Static configuration. Port, keys, etc. ====================
   // Certificate that should be used (includes private key)
@@ -39,6 +43,7 @@ private:
  
   //// Runtime data ============================================
   SSL_CTX * _sslctx;
+  TLSTickets * _TLSTickets;
   // Status of the server: Are we running, or not?
 
   // Setup functions

--- a/src/HTTPSServer.hpp
+++ b/src/HTTPSServer.hpp
@@ -36,6 +36,8 @@ public:
   // RFC 5077 TLS session tickets
   void enableTLSTickets(uint32_t liftimeSeconds = 86400, bool useHardwareRNG = false);
 
+  virtual HTTPSConnection * createConnection() override;
+
 private:
   // Static configuration. Port, keys, etc. ====================
   // Certificate that should be used (includes private key)
@@ -51,9 +53,6 @@ private:
   virtual void teardownSocket();
   uint8_t setupSSLCTX();
   uint8_t setupCert();
-
-  // Helper functions
-  virtual int createConnection(int idx);
 };
 
 } /* namespace httpsserver */

--- a/src/HTTPSServerConstants.hpp
+++ b/src/HTTPSServerConstants.hpp
@@ -7,6 +7,7 @@
 // 2: Error + Warn
 // 3: Error + Warn + Info
 // 4: Error + Warn + Info + Debug
+// 5: Error + Warn + Info + Debug + Verbose
 
 #ifndef HTTPS_LOGLEVEL
   #define HTTPS_LOGLEVEL 3
@@ -82,6 +83,12 @@
 #define HTTPS_CONNECTION_TIMEOUT               20000
 #endif
 
+// Timeout for connection in STATE_INITIAL to be considered idle.
+// When connection is idle, server may close it and switch to pending connection
+#ifndef HTTPS_CONNECTION_IDLE_TIMEOUT          
+#define HTTPS_CONNECTION_IDLE_TIMEOUT          500
+#endif 
+
 // Timeout used to wait for shutdown of SSL connection (ms)
 // (time for the client to return notify close flag) - without it, truncation attacks might be possible
 #ifndef HTTPS_SHUTDOWN_TIMEOUT
@@ -91,6 +98,15 @@
 // Length of a SHA1 hash
 #ifndef HTTPS_SHA1_LENGTH
 #define HTTPS_SHA1_LENGTH                      20
+#endif
+
+// Default values for workers. 
+// Stack size should not be less than 4096 for TLS connections
+#ifndef HTTPS_CONN_TASK_STACK_SIZE
+#define HTTPS_CONN_TASK_STACK_SIZE             4096
+#endif
+#ifndef HTTPS_CONN_TASK_PRIORITY
+#define HTTPS_CONN_TASK_PRIORITY               (tskIDLE_PRIORITY + 1)
 #endif
 
 #endif /* SRC_HTTPSSERVERCONSTANTS_HPP_ */

--- a/src/HTTPSServerConstants.hpp
+++ b/src/HTTPSServerConstants.hpp
@@ -42,6 +42,13 @@
   #define HTTPS_LOGD(...) do {} while (0)
 #endif
 
+#if HTTPS_LOGLEVEL > 4
+  #define HTTPS_LOGV(...) HTTPS_LOGTAG("D");Serial.printf(__VA_ARGS__);Serial.println()
+#else
+  #define HTTPS_LOGV(...) {}
+#endif
+
+
 // The following lines define limits of the protocol. Exceeding these limits will lead to a 500 error
 
 // Maximum of header lines that are parsed

--- a/src/HTTPWorker.cpp
+++ b/src/HTTPWorker.cpp
@@ -1,0 +1,67 @@
+#include "HTTPWorker.hpp"
+#include "HTTPServer.hpp"
+
+#include "freertos/semphr.h"
+
+namespace httpsserver {
+
+HTTPWorker::HTTPWorker(HTTPServer * server, size_t stackSize, int priority) {
+  _server = server;
+  BaseType_t taskRes = xTaskCreate(static_task, "HTTPSWorker", stackSize, this, priority, &_handle);
+  if (taskRes == pdTRUE) {
+    HTTPS_LOGI("Started connection task %p", _handle);
+  } else {
+    HTTPS_LOGE("Error starting connection task");
+    _running = false;
+  }
+}
+
+bool HTTPWorker::isRunning() {
+  return _running;
+}
+
+void HTTPWorker::run() {
+  // Run while server is running
+  while (_server->isRunning()) {
+
+    if (xSemaphoreTake(_server->_selectMutex, 0) == pdTRUE) {
+      // One worker task will manage the connections 
+      // i.e block on select call
+      HTTPS_LOGV("Task %p managing connections", _handle);
+      _server->manageConnections(HTTPS_CONNECTION_TIMEOUT);
+      xSemaphoreGive(_server->_selectMutex);
+    } else { 
+      // While others should wait for work from the queue
+       HTTPS_LOGV("Task %p waiting for work", _handle);
+      _server->doQueuedWork(portMAX_DELAY);
+    }
+
+    // Then all tasks complete any remaining work (without waiting)
+    while (_server->doQueuedWork(0));
+
+  } // while server->isRunning()
+
+} // HTTPConnectionTask::run;
+
+void HTTPWorker::start() {
+  vTaskResume(_handle);
+}
+
+void HTTPWorker::static_task(void* param) {
+  HTTPWorker * _this = static_cast<HTTPWorker *>(param);
+
+  // Start suspended wait for server to call start() method
+  vTaskSuspend(NULL);  
+
+  // Run the worker 
+  _this->run();
+
+  HTTPS_LOGI("Shutting down worker task %p", _this->_handle);
+  _this->_running = false;
+  // Mark the task for deltetion.
+  // The FreeRTOS idle task has reposnibilty to cleanup structures and memory
+  vTaskDelete(NULL);
+} 
+
+
+} // namespace httpsserver 

--- a/src/HTTPWorker.hpp
+++ b/src/HTTPWorker.hpp
@@ -1,0 +1,45 @@
+#ifndef SRC_HTTPWORKER_HPP_
+#define SRC_HTTPWORKER_HPP_
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "HTTPConnection.hpp"
+
+namespace httpsserver {
+
+class HTTPServer; // forward declaration
+
+class HTTPWorker {
+
+public:
+  HTTPWorker(HTTPServer * server, size_t stackSize, int priority);
+  void start();
+  bool isRunning();
+  
+protected:
+  // Create the instance flagged as running
+  // If constructor fails to start the actual task, 
+  // or task has ended due to server shutdown, this will be set to false.
+  bool _running = true;
+
+  // FreeRTOS task handle 
+  TaskHandle_t _handle = NULL;
+
+  // HTTP(S)Server to which this task is attached
+  HTTPServer * _server = NULL;
+
+  /**
+   * Worker (FreeRTOS task) main loop
+   */
+  void run();
+
+  /**
+   * Static method to start the worker in separate FreeRTOS task
+   */
+  static void static_task(void * param);
+};
+
+} // end namespace httpsserver
+
+#endif // SRC_HTTPWORKER_HPP_

--- a/src/ResourceResolver.cpp
+++ b/src/ResourceResolver.cpp
@@ -58,8 +58,7 @@ void ResourceResolver::resolveNode(const std::string &method, const std::string 
       std::string name  = param.substr(0, nvSplitIdx);
       std::string value = "";
       if (nvSplitIdx != std::string::npos) {
-        // TODO: There may be url encoding in here.
-        value = param.substr(nvSplitIdx+1);
+        value = urlDecode(param.substr(nvSplitIdx+1));
       }
 
       // Now we finally have name and value.
@@ -116,7 +115,7 @@ void ResourceResolver::resolveNode(const std::string &method, const std::string 
               // Second step: Grab the parameter value
               if (nodeIdx == nodepath.length()) {
                 // Easy case: parse until end of string
-                params->setUrlParameter(pIdx, resourceName.substr(urlIdx));
+                params->setUrlParameter(pIdx, urlDecode(resourceName.substr(urlIdx)));
               } else {
                 // parse until first char after the placeholder
                 char terminatorChar = nodepath[nodeIdx];
@@ -124,7 +123,7 @@ void ResourceResolver::resolveNode(const std::string &method, const std::string 
                 if (terminatorPosition != std::string::npos) {
                   // We actually found the terminator
                   size_t dynamicLength = terminatorPosition-urlIdx;
-                  params->setUrlParameter(pIdx, resourceName.substr(urlIdx, dynamicLength));
+                  params->setUrlParameter(pIdx, urlDecode(resourceName.substr(urlIdx, dynamicLength)));
                   urlIdx = urlIdx + dynamicLength;
                 } else {
                   // We did not find the terminator

--- a/src/TLSTickets.cpp
+++ b/src/TLSTickets.cpp
@@ -1,0 +1,91 @@
+#include "TLSTickets.hpp"
+#include "HTTPSServerConstants.hpp"
+
+#include "mbedtls/net_sockets.h"
+
+// Low level SSL implementation on ESP32
+// Copied from esp-idf/components/openssl/platform/ssl_pm.c 
+struct ssl_pm {    
+  mbedtls_net_context fd;
+  mbedtls_net_context cl_fd;
+  mbedtls_ssl_config conf; 
+  mbedtls_ctr_drbg_context ctr_drbg;
+  mbedtls_ssl_context ssl;
+  mbedtls_entropy_context entropy;
+};
+
+namespace httpsserver {
+
+int TLSTickets::hardware_random(void * p_rng, unsigned char * output, size_t output_len) {
+   esp_fill_random(output, output_len);
+   return 0;
+}
+
+TLSTickets::TLSTickets(const char* tag, uint32_t lifetimeSeconds, bool useHWRNG) {
+  _initOk = false;
+  _useHWRNG = useHWRNG;
+
+  // Setup TLS tickets context
+  int ret = -1;
+  if (_useHWRNG) {
+    mbedtls_ssl_ticket_init(&_ticketCtx);
+    ret = mbedtls_ssl_ticket_setup(
+      &_ticketCtx,
+      TLSTickets::hardware_random,
+      NULL,
+      MBEDTLS_CIPHER_AES_256_GCM, 
+      lifetimeSeconds
+    );
+  } else {
+		mbedtls_entropy_init(&_entropy); 			
+    mbedtls_ctr_drbg_init(&_ctr_drbg);
+    mbedtls_ssl_ticket_init(&_ticketCtx);
+    ret = mbedtls_ctr_drbg_seed(
+      &_ctr_drbg, 
+      mbedtls_entropy_func, 
+      &_entropy, 
+      (unsigned char*)tag, 
+      strlen(tag)
+    );
+    if (ret == 0) {
+      ret = mbedtls_ssl_ticket_setup(
+        &_ticketCtx,
+        mbedtls_ctr_drbg_random,
+        &_ctr_drbg,
+        MBEDTLS_CIPHER_AES_256_GCM, 
+        lifetimeSeconds
+      );    
+    }
+  }
+  if (ret != 0) return;
+
+  _initOk = true;
+  HTTPS_LOGI("Using TLS session tickets");
+}
+
+TLSTickets::~TLSTickets() {
+  if (!_useHWRNG) {
+    mbedtls_ctr_drbg_free(&_ctr_drbg);
+    mbedtls_entropy_free(&_entropy);
+  }
+  mbedtls_ssl_ticket_free(&_ticketCtx);
+}
+  
+bool TLSTickets::enable(SSL * ssl) {
+  bool res = false;
+  if (_initOk && ssl && ssl->ssl_pm) {      
+    // Get handle of low-level mbedtls structures for the session
+    struct ssl_pm * ssl_pm = (struct ssl_pm *) ssl->ssl_pm;
+    // Configure TLS ticket callbacks using default MbedTLS implementation
+    mbedtls_ssl_conf_session_tickets_cb(
+      &ssl_pm->conf,
+      mbedtls_ssl_ticket_write,
+      mbedtls_ssl_ticket_parse,
+      &_ticketCtx
+    );        
+    res = true;
+  }
+  return res;
+}
+    
+} /* namespace httpsserver */

--- a/src/TLSTickets.hpp
+++ b/src/TLSTickets.hpp
@@ -1,0 +1,57 @@
+#ifndef SRC_TLSTICKETS_HPP_
+#define SRC_TLSTICKETS_HPP_
+
+#include <cstdint>
+#include "mbedtls/entropy.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/ssl_ticket.h"
+#include "openssl/ssl.h"
+
+namespace httpsserver {
+
+/**
+ * Enables handling of RFC 5077 TLS session tickets
+ */
+class TLSTickets {
+
+public:
+  TLSTickets(const char* tag, uint32_t liftimeSecs, bool useHWRNG);
+  ~TLSTickets();
+
+  /**
+   * Enables TLS ticket processing for SSL session 
+   */
+  bool enable(SSL * ssl);
+
+protected:
+  bool _initOk;
+  bool _useHWRNG;
+
+  /**
+   * Holds TLS ticket keys
+   */
+  mbedtls_ssl_ticket_context _ticketCtx;
+
+  /**
+   * mbedTLS random number generator state
+   */
+	mbedtls_entropy_context _entropy; 			
+  mbedtls_ctr_drbg_context _ctr_drbg;  
+
+  /**
+   * MbedTLS Random Number Generator using ESP32's hardware RNG
+   * 
+   * NOTE: Radio (WiFi/Bluetooth) MUST be running for hardware
+   * entropy to be gathered. Otherwise this function is PRNG!
+   * 
+   * See more details about esp_random(), here:
+   * https://docs.espressif.com/projects/esp-idf/en/latest/api-reference/system/system.html
+   * 
+   */
+  static int hardware_random(void * p_rng, unsigned char * output, size_t output_len);
+
+};
+
+} /* namespace httpsserver */
+
+#endif // SRC_TLSTICKETS_HPP_

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -44,7 +44,7 @@ std::string intToString(int i) {
     return "0";
   }
   // We need this much digits
-  int digits = ceil(log10(i));
+  int digits = ceil(log10(i+1));
   char c[digits+1];
   c[digits] = '\0';
 
@@ -57,4 +57,35 @@ std::string intToString(int i) {
   return std::string(c);
 }
 
+}
+
+std::string urlDecode(std::string input) {
+  std::size_t idxReplaced = 0;
+  std::size_t idxFound = input.find('%');
+  while (idxFound != std::string::npos) {
+    if (idxFound <= input.length() + 3) {
+      char hex[2] = { input[idxFound+1], input[idxFound+2] };
+      byte val = 0;
+      for(int n = 0; n < sizeof(hex); n++) {
+        val <<= 4;
+        if ('0' <= hex[n] && hex[n] <= '9') {
+          val += hex[n]-'0';
+        }
+        else if ('A' <= hex[n] && hex[n] <= 'F') {
+          val += hex[n]-'A'+10;
+        }
+        else if ('a' <= hex[n] && hex[n] <= 'f') {
+          val += hex[n]-'a'+10;
+        }
+        else {
+          goto skipChar;
+        }
+      }
+      input.replace(idxFound, 3, 1, (char)val);
+    }
+    skipChar:
+    idxReplaced = idxFound + 1;
+    idxFound = input.find('%', idxReplaced);
+  }
+  return input;
 }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -27,4 +27,9 @@ std::string intToString(int i);
 
 }
 
+/**
+ * \brief **Utility function**: Removes URL encoding from the string (e.g. %20 -> space)
+ */
+std::string urlDecode(std::string input);
+
 #endif /* SRC_UTIL_HPP_ */


### PR DESCRIPTION
Two new API functions added:

HTTPSServer->enableTLSTickets(uint32_t liftimeSeconds = 86400, bool useHardwareRNG = false)
Which enables HTTPS server generating and accepting RFC5077 TLS tickets from clients for session negotiation vs. complete renegotiation for each TLS connection

HTTPServer->enableWorkers(uint8_t numWorkers = 2, size_t taskStackSize = HTTPS_CONN_TASK_STACK_SIZE, int taskPriority = HTTPS_CONN_TASK_PRIORITY);
Which creates n-FreeRTOS tasks that will takeover processing of server's loop() method. More than one task will enable parallel processing of connections as ESP32 has two cores and/or if single resourceNode's handler function is busy doing some longer processing 