### PR TITLE
Rewrite and Simplify Resource Resolving

### DIFF
--- a/src/HTTPNode.cpp
+++ b/src/HTTPNode.cpp
@@ -1,4 +1,5 @@
 #include "HTTPNode.hpp"
+#include "HTTPSServerConstants.hpp"
 
 namespace httpsserver {
 
@@ -6,64 +7,46 @@ namespace httpsserver {
     _path(path),
     _tag(tag),
     _nodeType(nodeType) {
-
-    // Create vector for valdiators
-    _validators = new std::vector<HTTPValidator*>();
-
-    // Count the parameters
-    _urlParamCount = 0;
+    // Count the parameters and store the indices
     size_t idx = 0;
     while((idx = path.find("/*", idx)) != std::string::npos) {
-      _urlParamCount+=1;
-      // If we don't do this, the same index will be found again... and again... and again...
-      idx+=1;
-    };
-
-    // Check if there are parameters
-    if (_urlParamCount > 0) {
-      // If there are parameters, store their indices
-      _urlParamIdx = new size_t[_urlParamCount];
-      for(int i = 0; i < _urlParamCount; i++) {
-        _urlParamIdx[i] = path.find("/*", i==0 ? 0 : _urlParamIdx[i-1])+1;
+      // Skip the "/*"
+      idx+=2;
+      // Assure that we have either /* at the URL's end or /*/ somewhere in between
+      if (idx == path.size() || path[idx] == '/') {
+        _urlParamIdx.push_back(idx - 1);
       }
-    } else {
-      _urlParamIdx = NULL;
-    }
+    };
   }
 
   HTTPNode::~HTTPNode() {
-    if (_urlParamIdx != NULL) {
-      delete[] _urlParamIdx;
-    }
-
     // Delete validator references
-    for(std::vector<HTTPValidator*>::iterator validator = _validators->begin(); validator != _validators->end(); ++validator) {
+    for(std::vector<HTTPValidator*>::iterator validator = _validators.begin(); validator != _validators.end(); ++validator) {
       delete *validator;
     }
-    delete _validators;
   }
 
   bool HTTPNode::hasUrlParameter() {
-    return _urlParamCount > 0;
+    return !_urlParamIdx.empty();
   }
 
-  size_t HTTPNode::getParamIdx(uint8_t idx) {
-    if (idx<_urlParamCount) {
+  ssize_t HTTPNode::getParamIdx(size_t idx) {
+    if (idx<_urlParamIdx.size()) {
       return _urlParamIdx[idx];
     } else {
       return -1;
     }
   }
 
-  uint8_t HTTPNode::getUrlParamCount() {
-    return _urlParamCount;
+  size_t HTTPNode::getUrlParamCount() {
+    return _urlParamIdx.size();
   }
 
   void HTTPNode::addURLParamValidator(uint8_t paramIdx, const HTTPValidationFunction * validator) {
-    _validators->push_back(new HTTPValidator(paramIdx, validator));
+    _validators.push_back(new HTTPValidator(paramIdx, validator));
   }
 
   std::vector<HTTPValidator*> * HTTPNode::getValidators() {
-    return _validators;
+    return &_validators;
   }
 }

--- a/src/HTTPNode.hpp
+++ b/src/HTTPNode.hpp
@@ -44,8 +44,8 @@ public:
   const HTTPNodeType _nodeType;
 
   bool hasUrlParameter();
-  uint8_t getUrlParamCount();
-  size_t getParamIdx(uint8_t);
+  size_t getUrlParamCount();
+  ssize_t getParamIdx(size_t);
 
   std::vector<HTTPValidator*> * getValidators();
 
@@ -61,9 +61,8 @@ public:
   void addURLParamValidator(uint8_t paramIdx, const HTTPValidationFunction * validator);
 
 private:
-  uint8_t _urlParamCount;
-  size_t * _urlParamIdx;
-  std::vector<HTTPValidator*> * _validators;
+  std::vector<size_t> _urlParamIdx;
+  std::vector<HTTPValidator*> _validators;
 };
 
 } // namespace httpserver

--- a/src/ResourceParameters.cpp
+++ b/src/ResourceParameters.cpp
@@ -1,4 +1,5 @@
 #include "ResourceParameters.hpp"
+#include "HTTPSServerConstants.hpp"
 
 namespace httpsserver {
 
@@ -46,7 +47,7 @@ void ResourceParameters::setRequestParameter(std::string const &name, std::strin
  *
  * The parameter idx defines the index of the parameter, starting with 0.
  */
-std::string ResourceParameters::getUrlParameter(uint8_t idx) {
+std::string ResourceParameters::getUrlParameter(size_t idx) {
   return _urlParams.at(idx);
 }
 
@@ -57,7 +58,7 @@ std::string ResourceParameters::getUrlParameter(uint8_t idx) {
  *
  * The parameter idx defines the index of the parameter, starting with 0.
  */
-uint16_t ResourceParameters::getUrlParameterInt(uint8_t idx) {
+uint16_t ResourceParameters::getUrlParameterInt(size_t idx) {
   return parseInt(getUrlParameter(idx));
 }
 
@@ -65,10 +66,12 @@ void ResourceParameters::resetUrlParameters() {
   _urlParams.clear();
 }
 
-void ResourceParameters::setUrlParameter(uint8_t idx, std::string const &val) {
-  if(idx>=_urlParams.capacity()) {
+void ResourceParameters::setUrlParameter(size_t idx, std::string const &val) {
+  if(idx>=_urlParams.size()) {
+    HTTPS_LOGD("Resizing from %d to %d", _urlParams.size(), idx + 1);
     _urlParams.resize(idx + 1);
   }
+  HTTPS_LOGD("Size is now %d, accessing idx %d", _urlParams.size(), idx);
   _urlParams.at(idx) = val;
 }
 

--- a/src/ResourceParameters.hpp
+++ b/src/ResourceParameters.hpp
@@ -29,11 +29,10 @@ public:
   uint16_t getRequestParameterInt(std::string const &name);
   void setRequestParameter(std::string const &name, std::string const &value);
 
-  std::string getUrlParameter(uint8_t idx);
-  uint16_t getUrlParameterInt(uint8_t idx);
+  std::string getUrlParameter(size_t idx);
+  uint16_t getUrlParameterInt(size_t idx);
   void resetUrlParameters();
-  void setUrlParameterCount(uint8_t idx);
-  void setUrlParameter(uint8_t idx, std::string const &val);
+  void setUrlParameter(size_t idx, std::string const &val);
 
 private:
   std::vector<std::string> _urlParams;


### PR DESCRIPTION
The resource resolver was quite complex and had issues when dealing with URL parameters containing placeholders not only at the end. Also, the combination of URL parameters (like `/my/endpoint/*`) in combination with request parameters (`/my/endpoint/42?some=value`) wasn't handled well.

This PR contains a rewrite of the resource resolver that tackles these issues.

**References**

- Resolves #53 