### PR TITLE
fix Websocket sent frame length

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -563,8 +563,15 @@ void HTTPConnection::loop() {
         HTTPS_LOGD("Calling WS handler, FID=%d", _socket);
         _wsHandler->loop();
       }
+
+      // If the client closed the connection unexpectedly
+      if (_clientState == CSTATE_CLOSED) {
+        HTTPS_LOGI("WS lost client, calling onClose, FID=%d", _socket);
+        _wsHandler->onClose();
+      }
+
       // If the handler has terminated the connection, clean up and close the socket too
-      if (_wsHandler->closed()) {
+      if (_wsHandler->closed() || _clientState == CSTATE_CLOSED) {
         HTTPS_LOGI("WS closed, freeing Handler, FID=%d", _socket);
         delete _wsHandler;
         _wsHandler = nullptr;

--- a/src/WebsocketHandler.cpp
+++ b/src/WebsocketHandler.cpp
@@ -238,7 +238,7 @@ void WebsocketHandler::send(uint8_t* data, uint16_t length, uint8_t sendType) {
     frame.len = 126;
     _con->writeBuffer((uint8_t *)&frame, sizeof(frame));
     uint16_t net_len = htons(length);
-    _con->writeBuffer((uint8_t *) net_len, sizeof(uint16_t));  // Convert to network byte order from host byte order
+    _con->writeBuffer((uint8_t *)&net_len, sizeof(uint16_t));  // Convert to network byte order from host byte order
   }
   _con->writeBuffer(data, length);
   HTTPS_LOGD("<< Websocket.send()");


### PR DESCRIPTION
Hi, while testing the Websocket feature and reviewing the code, I found a typo that would lead to a wrong frame length sent when the frame data is larger than 126 bytes.

I also notice that there will still be an issue when the sent data is larger than 2^16 bytes because the frame length must be encoded on 7 + 64 bits in that case. 