### PR TITLE
Fix infinite loop when a Websocket connection is lost

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -563,8 +563,15 @@ void HTTPConnection::loop() {
         HTTPS_LOGD("Calling WS handler, FID=%d", _socket);
         _wsHandler->loop();
       }
+
+      // If the client closed the connection unexpectedly
+      if (_clientState == CSTATE_CLOSED) {
+        HTTPS_LOGI("WS lost client, calling onClose, FID=%d", _socket);
+        _wsHandler->onClose();
+      }
+
       // If the handler has terminated the connection, clean up and close the socket too
-      if (_wsHandler->closed()) {
+      if (_wsHandler->closed() || _clientState == CSTATE_CLOSED) {
         HTTPS_LOGI("WS closed, freeing Handler, FID=%d", _socket);
         delete _wsHandler;
         _wsHandler = nullptr;


### PR DESCRIPTION
When a client closes a Websocket connection without performing a clean closing hand-shake, the server enters an infinite loop. This happens when the client web-browser is killed. I noticed this behaviour when swiping out Chrome on Android.

The suggested change might not be the best fix possible, but it works.