### PR TITLE
Added getHTTPHeaders() call to HTTPRequest.

### DIFF
--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -36,6 +36,10 @@ ResourceParameters * HTTPRequest::getParams() {
   return _params;
 }
 
+HTTPHeaders * HTTPRequest::getHTTPHeaders() {
+  return _headers;
+}
+
 std::string HTTPRequest::getHeader(std::string const &name) {
   HTTPHeader * h = _headers->get(name);
   if (h != NULL) {

--- a/src/HTTPRequest.hpp
+++ b/src/HTTPRequest.hpp
@@ -36,6 +36,7 @@ public:
   bool   requestComplete();
   void   discardRequestBody();
   ResourceParameters * getParams();
+  HTTPHeaders *getHTTPHeaders();
   std::string getBasicAuthUser();
   std::string getBasicAuthPassword();
   bool   isSecure();


### PR DESCRIPTION
This tiny modification allows access to the `HTTPHeaders` inside the `HTTPRequest`. It is needed for the WebServer.h compatibility library.