### PR TITLE
Add getClientIP() to HTTPRequest

### DIFF
--- a/src/ConnectionContext.hpp
+++ b/src/ConnectionContext.hpp
@@ -2,6 +2,7 @@
 #define SRC_CONNECTIONCONTEXT_HPP_
 
 #include <Arduino.h>
+#include <IPAddress.h>
 
 // Required for SSL
 #include "openssl/ssl.h"
@@ -30,6 +31,7 @@ public:
 
   virtual bool isSecure() = 0;
   virtual void setWebsocketHandler(WebsocketHandler *wsHandler);
+  virtual IPAddress getClientIP() = 0;
 
   WebsocketHandler * _wsHandler;
 };

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -2,6 +2,7 @@
 #define SRC_HTTPCONNECTION_HPP_
 
 #include <Arduino.h>
+#include <IPAddress.h>
 
 #include <string>
 #include <mbedtls/base64.h>
@@ -42,6 +43,7 @@ public:
   virtual int initialize(int serverSocketID, HTTPHeaders *defaultHeaders);
   virtual void closeConnection();
   virtual bool isSecure();
+  virtual IPAddress getClientIP();
 
   void loop();
   bool isClosed();

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -53,6 +53,10 @@ HTTPNode * HTTPRequest::getResolvedNode() {
   return _resolvedNode;
 }
 
+IPAddress HTTPRequest::getClientIP() {
+  return _con->getClientIP();
+}
+
 size_t HTTPRequest::readBytes(byte * buffer, size_t length) {
 
   // Limit reading to content length

--- a/src/HTTPRequest.hpp
+++ b/src/HTTPRequest.hpp
@@ -2,6 +2,7 @@
 #define SRC_HTTPREQUEST_HPP_
 
 #include <Arduino.h>
+#include <IPAddress.h>
 #include <string>
 
 #include <mbedtls/base64.h>
@@ -29,6 +30,7 @@ public:
   std::string getRequestString();
   std::string getMethod();
   std::string getTag();
+  IPAddress getClientIP();
 
   size_t readChars(char * buffer, size_t length);
   size_t readBytes(byte * buffer, size_t length);


### PR DESCRIPTION
Adds the method `getClientIP()` to the `HTTPRequest` class.

Usage in handler function or middleware:

```c++
IPAddress clientIP = req->getClientIP();
```

**Resolves:**
- #70 