### PR TITLE
Normalize Case of Header Names

### DIFF
--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -1,9 +1,13 @@
 #include "HTTPHeader.hpp"
 
+#include <locale>
+#include <ostream>
+#include <sstream>
+
 namespace httpsserver {
 
 HTTPHeader::HTTPHeader(const std::string &name, const std::string &value):
-  _name(name),
+  _name(normalizeHeaderName(name)),
   _value(value) {
     
 }
@@ -14,6 +18,26 @@ HTTPHeader::~HTTPHeader() {
 
 std::string HTTPHeader::print() {
   return _name + ": " + _value;
+}
+
+std::string normalizeHeaderName(std::string const &name) {
+  std::locale loc;
+  std::stringbuf buf;
+  std::ostream oBuf(&buf);
+  bool upper = true;
+  std::string::size_type len = name.length();
+  for (std::string::size_type i = 0; i < len; ++i) {
+    if (upper) {
+      oBuf << std::toupper(name[i], loc);
+      upper = false;
+    } else {
+      oBuf << std::tolower(name[i], loc);
+      if (!std::isalnum(name[i], loc)) {
+        upper=true;
+      }
+    }
+  }
+  return buf.str();
 }
 
 } /* namespace httpsserver */

--- a/src/HTTPHeader.hpp
+++ b/src/HTTPHeader.hpp
@@ -18,6 +18,15 @@ public:
   std::string print();
 };
 
+/**
+ * \brief Normalizes case in header names
+ * 
+ * It converts the first letter and every letter after a non-alnum character
+ * to uppercase. For example, "content-length" becomes "Content-Length" and
+ * "HOST" becomes "Host".
+ */
+std::string normalizeHeaderName(std::string const &name);
+
 } /* namespace httpsserver */
 
 #endif /* SRC_HTTPHEADER_HPP_ */

--- a/src/HTTPHeaders.cpp
+++ b/src/HTTPHeaders.cpp
@@ -13,8 +13,9 @@ HTTPHeaders::~HTTPHeaders() {
 }
 
 HTTPHeader * HTTPHeaders::get(std::string const &name) {
+  std::string normalizedName = normalizeHeaderName(name);
   for(std::vector<HTTPHeader*>::iterator header = _headers->begin(); header != _headers->end(); ++header) {
-    if ((*header)->_name.compare(name)==0) {
+    if ((*header)->_name.compare(normalizedName)==0) {
       return (*header);
     }
   }
@@ -22,8 +23,9 @@ HTTPHeader * HTTPHeaders::get(std::string const &name) {
 }
 
 std::string HTTPHeaders::getValue(std::string const &name) {
+  std::string normalizedName = normalizeHeaderName(name);
   for(std::vector<HTTPHeader*>::iterator header = _headers->begin(); header != _headers->end(); ++header) {
-    if ((*header)->_name.compare(name)==0) {
+    if ((*header)->_name.compare(normalizedName)==0) {
       return ((*header)->_value);
     }
   }


### PR DESCRIPTION
With this PR, case of header names is normalized so that the first letter and each first letter after a non-alphanumeric character is converted to uppercase and all other letters to lowercase.

Examples:
- `content-length` becomes `Content-Length`
- `HOST` becomes `Host`

That allows working with headers independently of their case, as specified in the RFCs listed below.

**References**

- [RFC 2616: Hyptertext Transfer Protocol](https://tools.ietf.org/html/rfc2616#section-4.2) on HTTP headers
- [RFC 822: Standard for the format of ARPA internet messages](https://tools.ietf.org/html/rfc822#section-3.4.7) on header structure, as referenced by RFC2616

**Issues**

- Resolve #73