### PR TITLE
Allow Overriding Default Keep-Alive Behavior

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -529,9 +529,15 @@ void HTTPConnection::loop() {
             // Now we need to check if we can use keep-alive to reuse the SSL connection
             // However, if the client did not set content-size or defined connection: close,
             // we have no chance to do so.
+            // Also, the programmer may have explicitly set Connection: close for the response.
+            std::string hConnection = res.getHeader("Connection");
+            if (hConnection == "close") {
+              _isKeepAlive = false;
+            }
             if (!_isKeepAlive) {
               // No KeepAlive -> We are done. Transition to next state.
               if (!isClosed()) {
+                res.finalize();
                 _connectionState = STATE_BODY_FINISHED;
               }
             } else {

--- a/src/HTTPHeader.cpp
+++ b/src/HTTPHeader.cpp
@@ -1,9 +1,13 @@
 #include "HTTPHeader.hpp"
 
+#include <locale>
+#include <ostream>
+#include <sstream>
+
 namespace httpsserver {
 
 HTTPHeader::HTTPHeader(const std::string &name, const std::string &value):
-  _name(name),
+  _name(normalizeHeaderName(name)),
   _value(value) {
     
 }
@@ -14,6 +18,26 @@ HTTPHeader::~HTTPHeader() {
 
 std::string HTTPHeader::print() {
   return _name + ": " + _value;
+}
+
+std::string normalizeHeaderName(std::string const &name) {
+  std::locale loc;
+  std::stringbuf buf;
+  std::ostream oBuf(&buf);
+  bool upper = true;
+  std::string::size_type len = name.length();
+  for (std::string::size_type i = 0; i < len; ++i) {
+    if (upper) {
+      oBuf << std::toupper(name[i], loc);
+      upper = false;
+    } else {
+      oBuf << std::tolower(name[i], loc);
+      if (!std::isalnum(name[i], loc)) {
+        upper=true;
+      }
+    }
+  }
+  return buf.str();
 }
 
 } /* namespace httpsserver */

--- a/src/HTTPHeader.hpp
+++ b/src/HTTPHeader.hpp
@@ -18,6 +18,15 @@ public:
   std::string print();
 };
 
+/**
+ * \brief Normalizes case in header names
+ * 
+ * It converts the first letter and every letter after a non-alnum character
+ * to uppercase. For example, "content-length" becomes "Content-Length" and
+ * "HOST" becomes "Host".
+ */
+std::string normalizeHeaderName(std::string const &name);
+
 } /* namespace httpsserver */
 
 #endif /* SRC_HTTPHEADER_HPP_ */

--- a/src/HTTPHeaders.cpp
+++ b/src/HTTPHeaders.cpp
@@ -13,8 +13,9 @@ HTTPHeaders::~HTTPHeaders() {
 }
 
 HTTPHeader * HTTPHeaders::get(std::string const &name) {
+  std::string normalizedName = normalizeHeaderName(name);
   for(std::vector<HTTPHeader*>::iterator header = _headers->begin(); header != _headers->end(); ++header) {
-    if ((*header)->_name.compare(name)==0) {
+    if ((*header)->_name.compare(normalizedName)==0) {
       return (*header);
     }
   }
@@ -22,8 +23,9 @@ HTTPHeader * HTTPHeaders::get(std::string const &name) {
 }
 
 std::string HTTPHeaders::getValue(std::string const &name) {
+  std::string normalizedName = normalizeHeaderName(name);
   for(std::vector<HTTPHeader*>::iterator header = _headers->begin(); header != _headers->end(); ++header) {
-    if ((*header)->_name.compare(name)==0) {
+    if ((*header)->_name.compare(normalizedName)==0) {
       return ((*header)->_value);
     }
   }

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -52,6 +52,15 @@ void HTTPResponse::setHeader(std::string const &name, std::string const &value) 
   _headers.set(new HTTPHeader(name, value));
 }
 
+std::string HTTPResponse::getHeader(std::string const &name) {
+  HTTPHeader * h = _headers.get(name);
+  if (h != NULL) {
+    return h->_value;
+  } else {
+    return std::string();
+  }
+}
+
 bool HTTPResponse::isHeaderWritten() {
   return _headerWritten;
 }

--- a/src/HTTPResponse.hpp
+++ b/src/HTTPResponse.hpp
@@ -32,6 +32,7 @@ public:
   uint16_t getStatusCode();
   std::string getStatusText();
   void setHeader(std::string const &name, std::string const &value);
+  std::string getHeader(std::string const &name);
   bool isHeaderWritten();
 
   void printStd(std::string const &str);


### PR DESCRIPTION
With this PR, the user of the library can call `res->setHeader("Connection", "close");` in a handler function to circumvent the default keep-alive behavior and force the server into closing the connection, even if the client requests to keep it alive.

**Issues/PRs**

- Resolve #75
- Depends on #77