### PR TITLE
WIP: Prevent crash on WebSocket request to non-WebSocket node.

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -519,9 +519,17 @@ void HTTPConnection::loop() {
 
           // Finally, after the handshake is done, we create the WebsocketHandler and change the internal state.
           if(websocketRequested) {
-            _wsHandler = ((WebsocketNode*)resolvedResource.getMatchingNode())->newHandler();
-            _wsHandler->initialize(this);  // make websocket with this connection 
-            _connectionState = STATE_WEBSOCKET;
+            HTTPNode *node = resolvedResource.getMatchingNode();
+
+            // Check for websocket request on non-websocket node:
+            if (node == nullptr || node->_nodeType != HTTPNodeType::WEBSOCKET) {
+              HTTPS_LOGW("Websocket request on non-websocket node rejected");
+              raiseError(404, "Not Found");
+            } else {
+              _wsHandler = ((WebsocketNode *) node)->newHandler();
+              _wsHandler->initialize(this);  // make websocket with this connection
+              _connectionState = STATE_WEBSOCKET;
+            }
           } else {
             // Handling the request is done
             HTTPS_LOGD("Handler function done, request complete");


### PR DESCRIPTION
This provides a partial fix for #51 to prevent the Guru from having to meditate. It's been tested on ESP32.

This now checks the HTTPNode type if a WebSocket was requested and only proceeds if the node is in fact a WebSocket, thus preventing the `newHandler()` call from failing on normal HTTP nodes.

#### TODO

Right now I'm calling `raiseError(404...` because that was the first copypaste I can find. I'm not actually sure the best way to reject the websocket connection as I'm not familiar with this library (just picked it up yesterday). This code is sufficient to move the crash over to the client side, which reports a bad frame header now.

A proper rejection should be sent, however that is accomplished in WebSocket land.

#### Testing

1. Clone and run the WebSocket chat server example from the master branch, and use https://www.websocket.org/echo.html to connect to the root URL on the device. This should panic and reset your ESP32. Connecting to `/chat` should work as expected.

2. Check out this PR and do the same. The ESP32 should no longer panic, and report the rejection of non-WebSocket request.