### PR TITLE
self-signed certificates: Add CN as subjectAltName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 New functionality:
 
-–
+– For self-signed certificates generated on the ESP32, the CN is now added as subjectAltName
 
 Bug fixes:
 
@@ -12,7 +12,7 @@ Bug fixes:
 
 Breaking changes:
 
-–
+– Generating self-signed certificates requires now a `CN=` as part of the distinguished name of the subject
 
 ## [v1.0.0](https://github.com/fhessel/esp32_https_server/releases/tag/v1.0.0)
 

--- a/src/SSLCert.hpp
+++ b/src/SSLCert.hpp
@@ -27,6 +27,7 @@
 #define HTTPS_SERVER_ERROR_CERTGEN_NAME 0x17
 #define HTTPS_SERVER_ERROR_CERTGEN_SERIAL 0x18
 #define HTTPS_SERVER_ERROR_CERTGEN_VALIDITY 0x19
+#define HTTPS_SERVER_ERROR_CERTGEN_CN 0x1a
 
 #endif // !HTTPS_DISABLE_SELFSIGNING
 
@@ -164,6 +165,8 @@ enum SSLKeySize {
  * The distinguished name (dn) parameter has to follow the x509 specifications. An example
  * would be:
  *   CN=myesp.local,O=acme,C=US
+ * 
+ * The subjectAltName is extracted from the CN component of the distinguished name.
  * 
  * The strings validFrom and validUntil have to be formatted like this:
  * "20190101000000", "20300101000000"


### PR DESCRIPTION
When creating self-signed certificates, add the `CN` in the subjectAltName extension so browsers stop complaining.

References:
- #112