### PR TITLE
GitHub Workflows: Update actions

### DIFF
--- a/.github/workflows/build-examples-master.yml
+++ b/.github/workflows/build-examples-master.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout codebase
-      uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - name: Set up Python
-      uses: actions/setup-python@9ac730844c47e52575257e93faf193c4530bc095
+      uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
       with:
         python-version: '3.8'
     - name: Install PlatformIO

--- a/.github/workflows/build-examples-pr.yml
+++ b/.github/workflows/build-examples-pr.yml
@@ -27,9 +27,9 @@ jobs:
     if: "contains( github.event.pull_request.labels.*.name, 'CI: Build Examples' )"
     steps:
     - name: Checkout codebase
-      uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - name: Set up Python
-      uses: actions/setup-python@9ac730844c47e52575257e93faf193c4530bc095
+      uses: actions/setup-python@3105fb18c05ddd93efea5f9e0bef7a03a6e9e7df
       with:
         python-version: '3.8'
     - name: Install PlatformIO
@@ -43,7 +43,7 @@ jobs:
     if: "contains( github.event.pull_request.labels.*.name, 'CI: Build Examples' )"
     steps:
     - name: Remove Label from PR
-      uses: octokit/request-action@57ec46afcc4c58c813af3afe67e57ced1ea9f165
+      uses: octokit/request-action@91508edec0a9561c2fefb9282491ced243bed312
       with:
         route: DELETE /repos/:repository/issues/:issue_number/labels/:name
         repository: ${{ github.repository }}


### PR DESCRIPTION
Update versions of actions used in pull request to conform with [latest changes regarding environments](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).