### PR TITLE
Fix infinite loop when the buffer ends with \r

### DIFF
--- a/src/HTTPConnection.cpp
+++ b/src/HTTPConnection.cpp
@@ -306,8 +306,8 @@ void HTTPConnection::readLine(int lengthLimit) {
       }
     } else {
       _parserLine.text += newChar;
-      _bufferProcessed += 1;
     }
+    _bufferProcessed += 1;
 
     // Check that the max request string size is not exceeded
     if (_parserLine.text.length() > lengthLimit) {

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -131,6 +131,8 @@ private:
   int _bufferProcessed;
   // The index on the receive_buffer that is the first one which is empty at the end.
   int _bufferUnusedIdx;
+  // If \r character has been read, in this case we expect \n to terminate the line
+  bool partialTerminationParsed = false;
 
   // Socket address, length etc for the connection
   struct sockaddr _sockAddr;


### PR DESCRIPTION
`HTTPConnection::readLine` has an infinite loop condition, when `\r` is the last character on the buffer, `_bufferProcessed` never gets updated, so the exit condition for the loop is never met.

With the modification in the first commit, the `\r` character gets accounted on its own and the buffer can be refreshed.
The downside is that the `\n` character will be considered on its own on the next iteration, and added to the `_pareserLine.text` rather than being grouped with `\r` and being counted as line terminator.

In the second commit, we keep track of the partial termination using a member variable, so as to detect the `\r\n` pair even when it happens across two different buffers, so that every problem with the first commit is resolved.