### PR TITLE
Fixed memory leak in the Websocket example

### DIFF
--- a/examples/Websocket-Chat/Websocket-Chat.ino
+++ b/examples/Websocket-Chat/Websocket-Chat.ino
@@ -169,6 +169,7 @@ void ChatHandler::onClose() {
       ChatHandler* client = activeClients[i];
       activeClients[i] = nullptr;
       delete client;
+      break;
     }
   }
 }

--- a/examples/Websocket-Chat/Websocket-Chat.ino
+++ b/examples/Websocket-Chat/Websocket-Chat.ino
@@ -166,7 +166,9 @@ WebsocketHandler * ChatHandler::create() {
 void ChatHandler::onClose() {
   for(int i = 0; i < MAX_CLIENTS; i++) {
     if (activeClients[i] == this) {
+      ChatHandler* client = activeClients[i];
       activeClients[i] = nullptr;
+      delete client;
     }
   }
 }


### PR DESCRIPTION
The heap will fill up with memory leaks if the pointer of previous clients is nullified without freeing up their allocated memory.