### PR TITLE
Quick fix for SHA headers changed

### DIFF
--- a/.github/workflows/build-examples-master.yml
+++ b/.github/workflows/build-examples-master.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - exp-jack-sha-header
 jobs:
   build-examples:
     strategy:

--- a/.github/workflows/build-examples-master.yml
+++ b/.github/workflows/build-examples-master.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - exp-jack-sha-header
 jobs:
   build-examples:
     strategy:

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <mbedtls/base64.h>
-#include <hwcrypto/sha.h>
+#include <esp32/sha.h>
 #include <functional>
 
 // Required for sockets

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <mbedtls/base64.h>
-#include <esp32/sha.h>
+#include <sha/sha_parallel_engine.h>
 #include <functional>
 
 // Required for sockets

--- a/src/WebsocketHandler.cpp
+++ b/src/WebsocketHandler.cpp
@@ -1,5 +1,9 @@
 #include "WebsocketHandler.hpp"
 
+#ifndef TAG
+static const char *TAG = "WebsocketHandler";
+#endif
+
 namespace httpsserver {
 
 /**


### PR DESCRIPTION
This is a quick fix for #163 #143 #136 and various others.

It is _not_ a full fix for moving to OpenSSL, which apparently is needed when we want to move to IDF 5.0 at some point in the future.