### PR TITLE
Fixed create_cert.sh script and updates sha import

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,14 +1,14 @@
 {
-  "name": "esp32_https_server",
+  "name": "esp32_brave_https_server",
   "keywords": "communication, esp32, http, https, server, ssl, tls, webserver, websockets",
   "description": "Alternative ESP32 Webserver implementation for the ESP32, supporting HTTPS and HTTP. The library provides TLS support and simultaneous connections. It can be used to run an HTTP or HTTPS server, or both in parallel. The server's resources are defined through handler and middleware functions, giving an easy start to everyone who has worked with frameworks like Express or Servlets before.",
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/fhessel/esp32_https_server.git"
+    "url": "https://github.com/LeBraveLittleToaster/esp32_brave_https_server"
   },
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "frameworks": "arduino",
   "platforms": ["espressif32"]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
 name=ESP32_HTTPS_Server
 version=1.0.0
 author=Frank Hessel <frank@fhessel.de>
-maintainer=Frank Hessel <frank@fhessel.de>
+maintainer=Pascal Schiessle <pascal.schiessle@web.de>
 sentence=Alternative ESP32 Webserver implementation for the ESP32, supporting HTTPS and HTTP.
 paragraph=The library provides TLS support and simultaneous connections. It can be used to run an HTTP or HTTPS server, or both in parallel. The server's resources are defined through handler and middleware functions, giving an easy start to everyone who has worked with frameworks like Express or Servlets before.
 category=Communication
-url=https://github.com/fhessel/esp32_https_server
+url=https://github.com/LeBraveLittleToaster/esp32_brave_https_server
 architectures=esp32
 includes=HTTPSServer.hpp,HTTPRequest.hpp,HTTPResponse.hpp

--- a/src/HTTPConnection.hpp
+++ b/src/HTTPConnection.hpp
@@ -6,7 +6,7 @@
 
 #include <string>
 #include <mbedtls/base64.h>
-#include <hwcrypto/sha.h>
+#include <esp32/sha.h>
 #include <functional>
 
 // Required for sockets


### PR DESCRIPTION
The cert creation script did not work properly with V3 OPENSSL specs. Updated the creation.

Also updated the sha import.

Tested on ESP32DEVKIT-V1.